### PR TITLE
Updated Casualty Stats for 2014

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,14 +36,14 @@
             </p>
 
             <ul>
-                <li>85 motorcyclists</li>
-                <li>116 pedestrians</li>
-                <li>172 cyclists</li>
+                <li>71 motorcyclists</li>
+                <li>105 pedestrians</li>
+                <li>197 cyclists</li>
             </ul>
 
             <p>Road casualty figures only include those reported to the police, so these figures do not include all casualties from all incidents</p>
 
-            <p class="source">Source: <a href="#rrc2012">RRC2012</a></p>
+            <p class="source">Source: <a href="#rrc2014">RRC2014</a></p>
         </div>
     </section>
 
@@ -51,15 +51,15 @@
     <section id="mort" class="mort">
         <div>
             <img src="i/ambulance.svg" alt="An ambulance"/>
-            <h1>90 of Portsmouth's<br>373 road casualties in 2012 involved <em>fatal or serious injury</em></h1>
-            <p>That's more than 7 of us every month</p>
-            <p>One every four days</p>
+            <h1>71 of Portsmouth's<br>373 road vulnerable road user casualties in 2014 involved <em>fatal</em> or <em>serious</em> injury</h1>
+            <p>That's nearly six of us every month</p>
+            <p>One every five days</p>
             <ul>
-                <li>29 motorcyclists</li>
-                <li>35 pedestrians</li>
-                <li>26 cyclists</li>
+                <li>23 motorcyclists</li>
+                <li>21 pedestrians</li>
+                <li>34 cyclists</li>
             </ul>
-            <p class="source">Source: <a href="#rrc2012">RRC2012</a></p>
+            <p class="source">Source: <a href="#rrc2014">RRC2014</a></p>
         </div>
     </section>
 
@@ -180,7 +180,7 @@
             <ul>
                 <li id="nomis"><a href="http://www.nomisweb.co.uk/census/2011/qs102ew">Nomis: Official Labour Market Statistics</a> http://www.nomisweb.co.uk/census/2011/qs102ew</li>
                 <li id="highwaycode"><a href="https://www.gov.uk/road-users-requiring-extra-care-204-to-225">The Highway Code</a> https://www.gov.uk/road-users-requiring-extra-care-204-to-225</li>
-                <li id=rrc2012><a href="https://www.gov.uk/government/publications/reported-road-casualties-great-britain-annual-report-2012">Reported Road Casualties 2012 - Sheet RAS30043</a> https://www.gov.uk/government/publications/reported-road-casualties-great-britain-annual-report-2012</li>
+                <li id=rrc2014><a href="https://www.gov.uk/government/publications/reported-road-casualties-great-britain-annual-report-2014">Reported Road Casualties 2014 - Sheet RAS30043</a> https://www.gov.uk/government/publications/reported-road-casualties-great-britain-annual-report-2014</li>
                 <li id="govdef"><a href="https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/254717/reported-road-casualties-gb-notes-definitions.pdf">UK Gov Definitions</a> https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/254717/reported-road-casualties-gb-notes-definitions.pdf</li>
                 <li id="tflrnpr8"><a href="http://www.tfl.gov.uk/cdn/static/cms/documents/traffic-note-8-cycling-red-lights.pdf">TfL RNPR 8</a> http://www.tfl.gov.uk/cdn/static/cms/documents/traffic-note-8-cycling-red-lights.pdf</li>
                 <li id="icycleliverpool"><a href="http://icycleliverpool.co.uk/2013/03/31/cyclist-fatalities/">I Cycle Liverpool</a> http://icycleliverpool.co.uk/2013/03/31/cyclist-fatalities/</li>

--- a/src/index.html
+++ b/src/index.html
@@ -30,7 +30,7 @@
     <section id="casualties" class="casualties">
         <div>
             <img src="i/injury.svg" alt="A person with their arm in a sling" />
-            <h1>373 of Portsmouth's vulnerable&nbsp;road&nbsp;users became <em>road casualties</em> during 2012</h1>
+            <h1>373 of Portsmouth's vulnerable&nbsp;road&nbsp;users became <em>road casualties</em> during 2014</h1>
 
             <p>One casualty for every day of the year<br>and a few spare<br>including:
             </p>


### PR DESCRIPTION
Interesting to note things seem to be getting better for peds & motor cyclists but worse for cyclists.
Net result is the same - 373 casualties in 2012, 373 casualties in 2014.
